### PR TITLE
Bugfix/gazebo plugins

### DIFF
--- a/ros1/Dockerfile
+++ b/ros1/Dockerfile
@@ -94,14 +94,6 @@ RUN apt-get update \
  && tar -xJvf "${NODE_RELEASE}.tar.xz" -C "${NODE_PATH}" \
  && rm -f "${NODE_RELEASE}.tar.xz"
 
-# Install relevant gazebo and image processing
-# plugins
-RUN apt-get update \
-   && apt-get install -y \
-        ros-${ROS_DISTRO}-gazebo-plugins \
-	ros-${ROS_DISTRO}-image-proc \
-	ros-${ROS_DISTRO}-image-transport-plugins
-
 # install vncserver
 RUN apt-get update \
  && export DEBIAN_FRONTEND=noninteractive \

--- a/ros1/Dockerfile
+++ b/ros1/Dockerfile
@@ -94,6 +94,14 @@ RUN apt-get update \
  && tar -xJvf "${NODE_RELEASE}.tar.xz" -C "${NODE_PATH}" \
  && rm -f "${NODE_RELEASE}.tar.xz"
 
+# Install relevant gazebo and image processing
+# plugins
+RUN apt-get update \
+   && apt-get install -y \
+        ros-${ROS_DISTRO}-gazebo-plugins \
+	ros-${ROS_DISTRO}-image-proc \
+	ros-${ROS_DISTRO}-image-transport-plugins
+
 # install vncserver
 RUN apt-get update \
  && export DEBIAN_FRONTEND=noninteractive \

--- a/ros1/robots/autorally/apt.list
+++ b/ros1/robots/autorally/apt.list
@@ -13,3 +13,7 @@ cutecom
 cmake-curses-gui
 synaptic 
 ros-melodic-rqt-publisher
+ros-melodic-gazebo-plugins
+ros-melodic-image-proc
+ros-melodic-image-transport-plugins
+

--- a/ros1/robots/baxter/apt.list
+++ b/ros1/robots/baxter/apt.list
@@ -12,3 +12,4 @@ python-wstool
 ros-indigo-tf-conversions
 ros-indigo-kdl-parser
 libgts-dev
+

--- a/ros1/robots/cob4/apt.list
+++ b/ros1/robots/cob4/apt.list
@@ -1,5 +1,3 @@
-ros-melodic-ros-control
-libeigen3-dev
 ros-melodic-gazebo-plugins
 ros-melodic-image-proc
 ros-melodic-image-transport-plugins

--- a/ros1/robots/f1tenth/apt.list
+++ b/ros1/robots/f1tenth/apt.list
@@ -3,5 +3,6 @@ ros-melodic-gazebo-ros-control
 ros-melodic-ros-controllers
 ros-melodic-navigation qt4-default
 ros-melodic-ackermann-msgs
-ros-melodic-serial
-ros-melodic-teb-local-planner*
+ros-melodic-gazebo-plugins
+ros-melodic-image-proc
+ros-melodic-image-transport-plugins

--- a/ros1/robots/f1tenth_tutorial/apt.list
+++ b/ros1/robots/f1tenth_tutorial/apt.list
@@ -6,3 +6,5 @@ ros-melodic-navigation qt4-default
 ros-melodic-ackermann-msgs
 ros-melodic-serial
 ros-melodic-teb-local-planner*
+ros-melodic-image-proc
+ros-melodic-image-transport-plugins

--- a/ros1/robots/fanuc/apt.list
+++ b/ros1/robots/fanuc/apt.list
@@ -1,0 +1,3 @@
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/fetch/apt.list
+++ b/ros1/robots/fetch/apt.list
@@ -1,1 +1,5 @@
 xvfb
+ros-melodic-gazebo-plugins
+ros-melodic-image-proc
+ros-melodic-image-transport-plugins
+

--- a/ros1/robots/guardian/apt.list
+++ b/ros1/robots/guardian/apt.list
@@ -1,3 +1,5 @@
 ros-indigo-gazebo-plugins
 ros-indigo-costmap-2d
 ros-indigo-ackermann-msgs
+ros-indigo-image-proc
+ros-indigo-image-transport-plugins

--- a/ros1/robots/heron/apt.list
+++ b/ros1/robots/heron/apt.list
@@ -1,0 +1,3 @@
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/husky/apt.list
+++ b/ros1/robots/husky/apt.list
@@ -1,5 +1,3 @@
-ros-melodic-ros-control
-libeigen3-dev
 ros-melodic-gazebo-plugins
 ros-melodic-image-proc
 ros-melodic-image-transport-plugins

--- a/ros1/robots/nao/apt.list
+++ b/ros1/robots/nao/apt.list
@@ -2,3 +2,6 @@ ros-indigo-humanoid-nav-msgs
 ros-indigo-gazebo-ros
 ros-indigo-control-toolbox
 libignition-math2-dev
+ros-indigo-gazebo-plugins
+ros-indigo-image-proc
+ros-indigo-image-transport-plugins

--- a/ros1/robots/pallet_truck/apt.list
+++ b/ros1/robots/pallet_truck/apt.list
@@ -1,0 +1,3 @@
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/pr2/apt.list
+++ b/ros1/robots/pr2/apt.list
@@ -1,0 +1,3 @@
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/rb2/apt.list
+++ b/ros1/robots/rb2/apt.list
@@ -1,5 +1,3 @@
-ros-melodic-ros-control
-libeigen3-dev
 ros-melodic-gazebo-plugins
 ros-melodic-image-proc
 ros-melodic-image-transport-plugins

--- a/ros1/robots/rbcar/apt.list
+++ b/ros1/robots/rbcar/apt.list
@@ -2,3 +2,6 @@ ros-kinetic-teleop-tools
 ros-kinetic-teleop-twist-joy
 ros-kinetic-twist-mux
 ros-kinetic-ros-control
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/summit_xl/apt.list
+++ b/ros1/robots/summit_xl/apt.list
@@ -2,3 +2,6 @@ ros-kinetic-teleop-tools
 ros-kinetic-teleop-twist-joy
 ros-kinetic-twist-mux
 ros-kinetic-ros-control
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/turtlebot/apt.list
+++ b/ros1/robots/turtlebot/apt.list
@@ -1,0 +1,3 @@
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins

--- a/ros1/robots/turtlebot3/apt.list
+++ b/ros1/robots/turtlebot3/apt.list
@@ -1,0 +1,4 @@
+ros-kinetic-gazebo-plugins
+ros-kinetic-image-proc
+ros-kinetic-image-transport-plugins
+

--- a/ros1/robots/warthog/apt.list
+++ b/ros1/robots/warthog/apt.list
@@ -1,5 +1,3 @@
-ros-melodic-ros-control
-libeigen3-dev
 ros-melodic-gazebo-plugins
 ros-melodic-image-proc
 ros-melodic-image-transport-plugins


### PR DESCRIPTION
This branch adds gazebo ros plugins, image proc, and image transport plugins, that are usually required to do Gazebo simulations in ROS. Currently, if they are not there, plugin loading will fail silently, but you won't have access to e.g. any camera.

Note, I've tried rebuilding all the images on this branch, but the following fail locally:

- baxter
- fanuc
- guardian
- nao
- turtlebot
- warthog

I think all but warthog are due to an intermittent network error. Warthog fails with a compilation error.
