### PR TITLE
Removed duplicate apt source for ros packages

### DIFF
--- a/ros1/Dockerfile
+++ b/ros1/Dockerfile
@@ -68,8 +68,6 @@ RUN apt-get update \
       wget \
  && echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list \
  && wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add - \
- && echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros-latest.list \
- && wget http://packages.ros.org/ros.key -O - | apt-key add - \
  && apt-get update \
  && pip install \
       catkin-tools==0.4.5 \


### PR DESCRIPTION
Prior to this change, we would get warnings about having a duplicate apt sources entry for ROS:
```
Processing triggers for libc-bin (2.23-0ubuntu11.3) ...
W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/ros-latest.list:1 and /etc/apt/sources.list.d/ros1-latest.list:1
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/ros-latest.list:1 and /etc/apt/sources.list.d/ros1-latest.list:1
```

I've tested building TurtleBot 3 with Kinetic with these changes and haven't seen any problems. I don't expect that we would have issues with other ROS distros, but we may want to check.