### PR TITLE
Add packages to apt.list necessary to run teleop for turtlebot3

### DIFF
--- a/ros1/robots/turtlebot3/apt.list
+++ b/ros1/robots/turtlebot3/apt.list
@@ -9,3 +9,5 @@ ros-kinetic-tf*
 ros-kinetic-interactive-markers
 ros-kinetic-gazebo-ros
 ros-kinetic-urdf*
+ros-kinetic-gazebo-ros-pkgs
+ros-kinetic-gazebo-ros-control


### PR DESCRIPTION
Without the added packages, after launching turtlebot3_teleop_key.launch any input has no effect in moving the turtlebot